### PR TITLE
GNU linker library order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(objects): src/%.o: src/%.cpp
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(target): $(objects)
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:
 	rm -f src/*.o $(target)


### PR DESCRIPTION
The GNU linker likes its libraries after the object files, otherwise the necessary symbols/shared libraries won't be found.
Fixes #14 